### PR TITLE
Renamed inconsistent identifiers

### DIFF
--- a/vlayout/src/main/java/com/alibaba/android/vlayout/RangeLayoutHelperFinder.java
+++ b/vlayout/src/main/java/com/alibaba/android/vlayout/RangeLayoutHelperFinder.java
@@ -117,12 +117,12 @@ public class RangeLayoutHelperFinder extends LayoutHelperFinder {
     @Nullable
     @Override
     protected LayoutHelper getLayoutHelper(int position) {
-        final int helperCount = mLayoutHelperItems.size();
-        if (helperCount == 0) {
+        final int count = mLayoutHelperItems.size();
+        if (count == 0) {
             return null;
         }
 
-        int s = 0, e = helperCount - 1, m;
+        int s = 0, e = count - 1, m;
         LayoutHelperItem rs = null;
 
         // binary search range

--- a/vlayout/src/main/java/com/alibaba/android/vlayout/layout/GridLayoutHelper.java
+++ b/vlayout/src/main/java/com/alibaba/android/vlayout/layout/GridLayoutHelper.java
@@ -669,7 +669,7 @@ public class GridLayoutHelper extends BaseLayoutHelper {
     }
 
     private void assignSpans(RecyclerView.Recycler recycler, RecyclerView.State state, int count,
-                             int consumedSpanCount, boolean layingOutInPrimaryDirection, LayoutManagerHelper layoutManagerHelper) {
+                             int consumedSpanCount, boolean layingOutInPrimaryDirection, LayoutManagerHelper helper) {
         int span, spanDiff, start, end, diff;
         // make sure we traverse from min position to max position
         if (layingOutInPrimaryDirection) {
@@ -682,7 +682,7 @@ public class GridLayoutHelper extends BaseLayoutHelper {
             diff = -1;
         }
 
-        if (layoutManagerHelper.getOrientation() == VERTICAL && layoutManagerHelper.isDoLayoutRTL()) { // start from last span
+        if (helper.getOrientation() == VERTICAL && helper.isDoLayoutRTL()) { // start from last span
             span = consumedSpanCount - 1;
             spanDiff = -1;
         } else {
@@ -692,7 +692,7 @@ public class GridLayoutHelper extends BaseLayoutHelper {
 
         for (int i = start; i != end; i += diff) {
             View view = mSet[i];
-            int spanSize = getSpanSize(recycler, state, layoutManagerHelper.getPosition(view));
+            int spanSize = getSpanSize(recycler, state, helper.getPosition(view));
             if (spanDiff == -1 && spanSize > 1) {
                 mSpanIndices[i] = span - (spanSize - 1);
             } else {
@@ -711,8 +711,8 @@ public class GridLayoutHelper extends BaseLayoutHelper {
         }
 
         @Override
-        public int getSpanIndex(int position, int spanCount) {
-            return (position - mStartPosition) % spanCount;
+        public int getSpanIndex(int span, int spanCount) {
+            return (span - mStartPosition) % spanCount;
         }
     }
 

--- a/vlayout/src/main/java/com/alibaba/android/vlayout/layout/StaggeredGridLayoutHelper.java
+++ b/vlayout/src/main/java/com/alibaba/android/vlayout/layout/StaggeredGridLayoutHelper.java
@@ -1161,12 +1161,12 @@ public class StaggeredGridLayoutHelper extends BaseLayoutHelper {
          * @param end   The end line
          * @return true if a new child can be added between start and end
          */
-        boolean isEmpty(int start, int end, OrientationHelper helper) {
+        boolean isEmpty(int start, int end, OrientationHelper orientationHelper) {
             final int count = mViews.size();
             for (int i = 0; i < count; i++) {
                 final View view = mViews.get(i);
-                if (helper.getDecoratedStart(view) < end &&
-                        helper.getDecoratedEnd(view) > start) {
+                if (orientationHelper.getDecoratedStart(view) < end &&
+                        orientationHelper.getDecoratedEnd(view) > start) {
                     return false;
                 }
             }

--- a/vlayout/src/main/java/com/alibaba/android/vlayout/layout/StickyLayoutHelper.java
+++ b/vlayout/src/main/java/com/alibaba/android/vlayout/layout/StickyLayoutHelper.java
@@ -263,10 +263,10 @@ public class StickyLayoutHelper extends FixAreaLayoutHelper {
                 if (mStickyStart) {
                     for (int i = helper.getChildCount() - 1; i >= 0; i--) {
                         refer = helper.getChildAt(i);
-                        int pos = helper.getPosition(refer);
-                        if (pos < mPos) { // TODO: when view size is larger than totalSpace!
+                        int anchorPos = helper.getPosition(refer);
+                        if (anchorPos < mPos) { // TODO: when view size is larger than totalSpace!
                             top = orientationHelper.getDecoratedEnd(refer);
-                            LayoutHelper layoutHelper = helper.findLayoutHelperByPosition(pos);
+                            LayoutHelper layoutHelper = helper.findLayoutHelperByPosition(anchorPos);
                             if (layoutHelper instanceof MarginLayoutHelper) {
                                 top = top + ((MarginLayoutHelper) layoutHelper).mMarginBottom + ((MarginLayoutHelper) layoutHelper).mPaddingBottom;
                             }
@@ -282,10 +282,10 @@ public class StickyLayoutHelper extends FixAreaLayoutHelper {
                 } else {
                     for (int i = 0; i < helper.getChildCount(); i++) {
                         refer = helper.getChildAt(i);
-                        int pos = helper.getPosition(refer);
-                        if (pos > mPos) {
+                        int anchorPos = helper.getPosition(refer);
+                        if (anchorPos > mPos) {
                             bottom = orientationHelper.getDecoratedStart(refer);
-                            LayoutHelper layoutHelper = helper.findLayoutHelperByPosition(pos);
+                            LayoutHelper layoutHelper = helper.findLayoutHelperByPosition(anchorPos);
                             if (layoutHelper instanceof MarginLayoutHelper) {
                                 bottom = bottom - ((MarginLayoutHelper) layoutHelper).mMarginTop - ((MarginLayoutHelper) layoutHelper).mPaddingTop;
                             }
@@ -399,10 +399,10 @@ public class StickyLayoutHelper extends FixAreaLayoutHelper {
                         if (mStickyStart) {
                             for (int i = helper.getChildCount() - 1; i >= 0; i--) {
                                 refer = helper.getChildAt(i);
-                                int pos = helper.getPosition(refer);
-                                if (pos < mPos) { // TODO: when view size is larger than totalSpace!
+                                int anchorPos = helper.getPosition(refer);
+                                if (anchorPos < mPos) { // TODO: when view size is larger than totalSpace!
                                     top = orientationHelper.getDecoratedEnd(refer);
-                                    LayoutHelper layoutHelper = helper.findLayoutHelperByPosition(pos);
+                                    LayoutHelper layoutHelper = helper.findLayoutHelperByPosition(anchorPos);
                                     if (layoutHelper instanceof MarginLayoutHelper) {
                                         top = top + ((MarginLayoutHelper) layoutHelper).mMarginBottom + ((MarginLayoutHelper) layoutHelper).mPaddingBottom;
                                     }
@@ -414,10 +414,10 @@ public class StickyLayoutHelper extends FixAreaLayoutHelper {
                         } else {
                             for (int i = 0; i < helper.getChildCount(); i++) {
                                 refer = helper.getChildAt(i);
-                                int pos = helper.getPosition(refer);
-                                if (pos > mPos) {
+                                int anchorPos = helper.getPosition(refer);
+                                if (anchorPos > mPos) {
                                     bottom = orientationHelper.getDecoratedStart(refer);
-                                    LayoutHelper layoutHelper = helper.findLayoutHelperByPosition(pos);
+                                    LayoutHelper layoutHelper = helper.findLayoutHelperByPosition(anchorPos);
                                     if (layoutHelper instanceof MarginLayoutHelper) {
                                         bottom = bottom - ((MarginLayoutHelper) layoutHelper).mMarginTop - ((MarginLayoutHelper) layoutHelper).mPaddingTop;
                                     }
@@ -464,8 +464,8 @@ public class StickyLayoutHelper extends FixAreaLayoutHelper {
                         if (mStickyStart) {
                             for (int i = helper.getChildCount() - 1; i >= 0; i--) {
                                 refer = helper.getChildAt(i);
-                                int pos = helper.getPosition(refer);
-                                if (pos < mPos) { // TODO: when view size is larger than totalSpace!
+                                int anchorPos = helper.getPosition(refer);
+                                if (anchorPos < mPos) { // TODO: when view size is larger than totalSpace!
                                     left = orientationHelper.getDecoratedEnd(refer);
                                     right = left + consumed;
                                     break;
@@ -474,8 +474,8 @@ public class StickyLayoutHelper extends FixAreaLayoutHelper {
                         } else {
                             for (int i = 0; i < helper.getChildCount(); i++) {
                                 refer = helper.getChildAt(i);
-                                int pos = helper.getPosition(refer);
-                                if (pos > mPos) {
+                                int anchorPos = helper.getPosition(refer);
+                                if (anchorPos > mPos) {
                                     right = orientationHelper.getDecoratedStart(refer);
                                     left = right - consumed;
                                     break;


### PR DESCRIPTION
I used an automatic tool which suggests useful renaming operations based on the frequency such names appear in the code-base. For example, "count" appears more frequently than "helperCount" in the context in which "helperCount" is used, so I renamed it. I did not modify functional parts of the code, I just applied such renamings.