### PR TITLE
修复 子Adapter复写onBindViewHolder(VH holder, int position, List<Object> p…

### DIFF
--- a/vlayout/src/main/java/com/alibaba/android/vlayout/DelegateAdapter.java
+++ b/vlayout/src/main/java/com/alibaba/android/vlayout/DelegateAdapter.java
@@ -105,7 +105,7 @@ public class DelegateAdapter extends VirtualLayoutAdapter<RecyclerView.ViewHolde
         if (mHasConsistItemType) {
             Adapter adapter = mItemTypeAry.get(viewType);
             if (adapter != null) {
-                 return adapter.onCreateViewHolder(parent, viewType);
+                return adapter.onCreateViewHolder(parent, viewType);
             }
 
             return null;
@@ -119,7 +119,7 @@ public class DelegateAdapter extends VirtualLayoutAdapter<RecyclerView.ViewHolde
         int index = viewType - t;
         int subItemType = w - index;
 
-        Adapter adapter  = findAdapterByIndex(index);
+        Adapter adapter = findAdapterByIndex(index);
         if (adapter == null) {
             return null;
         }
@@ -142,7 +142,7 @@ public class DelegateAdapter extends VirtualLayoutAdapter<RecyclerView.ViewHolde
             return;
         }
         pair.second.onBindViewHolder(holder, position - pair.first.mStartPosition, payloads);
-        pair.second.onBindViewHolderWithOffset(holder, position - pair.first.mStartPosition, position);
+        pair.second.onBindViewHolderWithOffset(holder, position - pair.first.mStartPosition, position, payloads);
 
     }
 
@@ -421,12 +421,11 @@ public class DelegateAdapter extends VirtualLayoutAdapter<RecyclerView.ViewHolde
         mIndexAry.clear();
     }
 
-    public int getAdaptersCount(){
+    public int getAdaptersCount() {
         return mAdapters == null ? 0 : mAdapters.size();
     }
 
     /**
-     *
      * @param absoultePosition
      * @return the relative position in sub adapter by the absoulte position in DelegaterAdapter. Return -1 if no sub adapter founded.
      */
@@ -503,7 +502,7 @@ public class DelegateAdapter extends VirtualLayoutAdapter<RecyclerView.ViewHolde
             return mIndex;
         }
 
-        private boolean updateLayoutHelper(){
+        private boolean updateLayoutHelper() {
             if (mIndex < 0) {
                 return false;
             }
@@ -656,6 +655,10 @@ public class DelegateAdapter extends VirtualLayoutAdapter<RecyclerView.ViewHolde
 
         protected void onBindViewHolderWithOffset(VH holder, int position, int offsetTotal) {
 
+        }
+
+        protected void onBindViewHolderWithOffset(VH holder, int position, int offsetTotal, List<Object> payloads) {
+            onBindViewHolderWithOffset(holder, position, offsetTotal);
         }
     }
 

--- a/vlayout/src/main/java/com/alibaba/android/vlayout/DelegateAdapter.java
+++ b/vlayout/src/main/java/com/alibaba/android/vlayout/DelegateAdapter.java
@@ -130,13 +130,20 @@ public class DelegateAdapter extends VirtualLayoutAdapter<RecyclerView.ViewHolde
     @SuppressWarnings("unchecked")
     @Override
     public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
+
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void onBindViewHolder(RecyclerView.ViewHolder holder, int position, List<Object> payloads) {
+        super.onBindViewHolder(holder, position, payloads);
         Pair<AdapterDataObserver, Adapter> pair = findAdapterByPosition(position);
         if (pair == null) {
             return;
         }
-
-        pair.second.onBindViewHolder(holder, position - pair.first.mStartPosition);
+        pair.second.onBindViewHolder(holder, position - pair.first.mStartPosition, payloads);
         pair.second.onBindViewHolderWithOffset(holder, position - pair.first.mStartPosition, position);
+
     }
 
     @Override
@@ -567,6 +574,14 @@ public class DelegateAdapter extends VirtualLayoutAdapter<RecyclerView.ViewHolde
                 return;
             }
             notifyItemRangeChanged(mStartPosition + positionStart, itemCount);
+        }
+
+        @Override
+        public void onItemRangeChanged(int positionStart, int itemCount, Object payload) {
+            if (!updateLayoutHelper()) {
+                return;
+            }
+            notifyItemRangeChanged(mStartPosition + positionStart, itemCount, payload);
         }
     }
 


### PR DESCRIPTION
Fix在DelegateAdapter中，子Adapter复写onBindViewHolder(VH holder, int position, List<Object> payloads)的时候跳过该方法，直接执行onBindViewHolder(VH holder, int position)方法