### PR TITLE
ClassCastException by dynamic setAdapters

### DIFF
--- a/examples/src/main/AndroidManifest.xml
+++ b/examples/src/main/AndroidManifest.xml
@@ -58,6 +58,7 @@
         <activity android:name="com.alibaba.android.vlayout.example.DebugActivity">
 
         </activity>
+        <activity android:name=".DynamicAdapterActivity" />
 
     </application>
 

--- a/examples/src/main/java/com/alibaba/android/vlayout/example/DynamicAdapter.java
+++ b/examples/src/main/java/com/alibaba/android/vlayout/example/DynamicAdapter.java
@@ -1,0 +1,126 @@
+package com.alibaba.android.vlayout.example;
+
+import android.support.v4.util.ArraySet;
+import android.support.v4.util.SparseArrayCompat;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import com.alibaba.android.vlayout.DelegateAdapter;
+import com.alibaba.android.vlayout.LayoutHelper;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Set;
+
+/**
+ * <>
+ *
+ * @author lixi
+ * @date 2019/1/31
+ */
+public class DynamicAdapter<VH extends RecyclerView.ViewHolder> extends DelegateAdapter.Adapter<VH> {
+
+    public static final int CLASS_CAST_EXECPTION = -10086;
+    private static final SparseArrayCompat<Set<String>> CACHE = new SparseArrayCompat<>();
+
+    public static SparseArrayCompat<Set<String>> getCache() {
+        return CACHE;
+    }
+
+    private static void addToCache(int viewType, Class clazz) {
+        addToCache(viewType, clazz.getSimpleName());
+    }
+
+
+    private static void addToCache(int viewType, String clazzName) {
+        SparseArrayCompat<Set<String>> cache = getCache();
+        Set<String> history = cache.get(viewType);
+        if (null == history) {
+            history = new ArraySet<>();
+        }
+        history.add(clazzName);
+        cache.put(viewType, history);
+    }
+
+    private int mItemCount;
+    private LayoutHelper mLayoutHelper;
+    private Class<VH> mClazz;
+
+    public DynamicAdapter(LayoutHelper helper, int itemCount, Class<VH> clazz) {
+        this.mItemCount = itemCount;
+        this.mLayoutHelper = helper;
+        this.mClazz = clazz;
+    }
+
+    @Override
+    public int getItemCount() {
+        return mItemCount;
+    }
+
+    @Override
+    public LayoutHelper onCreateLayoutHelper() {
+        return mLayoutHelper;
+    }
+
+    @Override
+    public VH onCreateViewHolder(ViewGroup parent, int viewType) {
+        View itemView = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.item, parent, false);
+
+        itemView.setMinimumHeight((int) (parent.getResources().getDisplayMetrics().density * 72));
+
+        RecyclerView.LayoutParams params = new RecyclerView.LayoutParams(
+                RecyclerView.LayoutParams.MATCH_PARENT,
+                RecyclerView.LayoutParams.WRAP_CONTENT
+        );
+        itemView.setLayoutParams(params);
+
+        try {
+            Constructor<VH> constructor = mClazz.getConstructor(View.class);
+            return constructor.newInstance(itemView);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch (InstantiationException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void onBindViewHolder(VH holder, int position) {
+
+    }
+
+
+    @Override
+    protected void onBindViewHolderWithOffset(VH holder, int position, int offsetTotal) {
+        super.onBindViewHolderWithOffset(holder, position, offsetTotal);
+        addToCache(holder.getItemViewType(), mClazz);
+
+
+        StringBuilder title = new StringBuilder(mClazz.getSimpleName())
+                .append("\n")
+                .append("[Position]:")
+                .append(offsetTotal)
+                .append("\n")
+                .append("[ViewType]:")
+                .append(holder.getItemViewType());
+
+        if (!mClazz.isAssignableFrom(holder.getClass())) {
+            addToCache(CLASS_CAST_EXECPTION, holder.getClass().getSimpleName() + " cast to " + mClazz.getSimpleName());
+
+            title = title.append("\n").append(mClazz.getSimpleName())
+                    .append(" cannot be cast to ").append(holder.getClass().getSimpleName());
+        }
+
+        ((TextView) holder.itemView.findViewById(R.id.title)).setText(title);
+    }
+
+
+}

--- a/examples/src/main/java/com/alibaba/android/vlayout/example/DynamicAdapterActivity.java
+++ b/examples/src/main/java/com/alibaba/android/vlayout/example/DynamicAdapterActivity.java
@@ -1,0 +1,317 @@
+package com.alibaba.android.vlayout.example;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.support.v4.util.SparseArrayCompat;
+import android.support.v7.widget.ListPopupWindow;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.ArrayAdapter;
+
+import com.alibaba.android.vlayout.DelegateAdapter;
+import com.alibaba.android.vlayout.LayoutHelper;
+import com.alibaba.android.vlayout.VirtualLayoutManager;
+import com.alibaba.android.vlayout.layout.GridLayoutHelper;
+import com.alibaba.android.vlayout.layout.LinearLayoutHelper;
+import com.alibaba.android.vlayout.layout.OnePlusNLayoutHelper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+/**
+ * <>
+ *
+ * @author lixi
+ * @date 2019/1/31
+ */
+public class DynamicAdapterActivity extends Activity {
+
+    private List<DelegateAdapter.Adapter> mReadOnlyAdapters = Collections.emptyList();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.dynamic_adapter_activity);
+
+        final RecyclerView recyclerView = (RecyclerView) findViewById(R.id.main_view);
+        final VirtualLayoutManager layoutManager = new VirtualLayoutManager(this);
+        recyclerView.setLayoutManager(layoutManager);
+
+        final DelegateAdapter delegateAdapter = new DelegateAdapter(layoutManager);
+        recyclerView.setAdapter(delegateAdapter);
+
+        List<DelegateAdapter.Adapter> adapters = new LinkedList<>();
+        adapters.add(randomAdapter());
+        adapters.add(randomAdapter());
+        delegateAdapter.setAdapters(adapters);
+
+        mReadOnlyAdapters = Collections.unmodifiableList(adapters);
+        findViewById(R.id.add_button).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                List<DelegateAdapter.Adapter> adapters = new ArrayList<>(mReadOnlyAdapters);
+                adapters.add(randomAdapter());
+                mReadOnlyAdapters = Collections.unmodifiableList(adapters);
+                delegateAdapter.setAdapters(adapters);
+            }
+        });
+
+
+        findViewById(R.id.remove_button).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (mReadOnlyAdapters.isEmpty()) {
+                    return;
+                }
+
+                List<DelegateAdapter.Adapter> adapters = new ArrayList<>(mReadOnlyAdapters);
+                int index = adapters.size() / 2;
+                adapters.remove(random.nextInt(Math.max(1, index)));
+                mReadOnlyAdapters = Collections.unmodifiableList(adapters);
+                delegateAdapter.setAdapters(adapters);
+            }
+        });
+
+        final int popupWindowWidth = (int) (getResources().getDisplayMetrics().density * 220 + 0.5F);
+
+        findViewById(R.id.display_history_button).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                SparseArrayCompat<Set<String>> cache = DynamicAdapter.getCache();
+                List<String> lists = new ArrayList<>();
+                int size = cache.size();
+                for (int i = 0; i < size; i++) {
+                    int key = cache.keyAt(i);
+                    if (key == DynamicAdapter.CLASS_CAST_EXECPTION) {
+                        lists.add("ClassCastException:");
+                        Set<String> history = cache.valueAt(i);
+                        for (String clazz : history) {
+                            lists.add("    " + clazz);
+                        }
+                    } else {
+                        lists.add("Cantor ViewType:  " + key);
+                        Set<String> history = cache.valueAt(i);
+                        for (String clazz : history) {
+                            lists.add("        " + clazz);
+                        }
+                    }
+                }
+                ListPopupWindow popupWindow = new ListPopupWindow(v.getContext());
+                popupWindow.setAdapter(new ArrayAdapter<>(v.getContext(), android.R.layout.simple_list_item_1, lists));
+                popupWindow.setAnchorView(v);
+                popupWindow.setContentWidth(popupWindowWidth);
+                popupWindow.show();
+
+            }
+        });
+
+    }
+
+
+    private final Class[] classes = {
+            ViewHolder1.class,
+            ViewHolder2.class,
+            ViewHolder3.class,
+            ViewHolder4.class,
+            ViewHolder5.class,
+            ViewHolder6.class,
+            ViewHolder7.class,
+            ViewHolder8.class,
+            ViewHolder9.class,
+            ViewHolder10.class,
+            ViewHolder11.class,
+            ViewHolder12.class,
+            ViewHolder13.class,
+            ViewHolder14.class,
+            ViewHolder15.class,
+            ViewHolder16.class,
+            ViewHolder17.class,
+            ViewHolder18.class,
+            ViewHolder19.class,
+            ViewHolder20.class
+    };
+
+    private DelegateAdapter.Adapter randomAdapter() {
+        @SuppressWarnings("unchecked")
+        Class<? extends RecyclerView.ViewHolder> holderClazz = classes[random.nextInt(classes.length)];
+
+        return new DynamicAdapter<>(randomLayoutHelper(), Math.max(1, random.nextInt(5)), holderClazz);
+    }
+
+
+    private final Random random = new Random();
+
+    private LayoutHelper randomLayoutHelper() {
+        int index = random.nextInt(3);
+        switch (index) {
+            case 0:
+                return new GridLayoutHelper(Math.max(2, random.nextInt(5)));
+            case 1:
+                return new OnePlusNLayoutHelper();
+
+            // TODO 搭配 StaggeredGridLayoutHelper 使用时有可能导致界面显示异常（ remainingSpace 提前用完，导致后续界面不再绘制，滑动后正常显示 ）
+            //
+            // RANGE(2,2) LayoutState.mCurrentPosition=3
+            // final int maxEnd = getMaxEnd(orientationHelper.getEndAfterPadding(), orientationHelper);
+            // unusedSpace = maxEnd - offset - padding - margin (offset = 0, padding = 0, margin = 0)
+            // result.mConsumed = unusedSpace
+            // layoutState.mAvailable -= layoutChunkResultCache.mConsumed;
+            // remainingSpace = layoutState.mAvailable = 0
+            //
+            // case 2:
+            // return new StaggeredGridLayoutHelper(3);
+
+            default: {
+                return new LinearLayoutHelper();
+            }
+        }
+
+    }
+
+
+    public static class ViewHolder1 extends RecyclerView.ViewHolder {
+
+        public ViewHolder1(View itemView) {
+            super(itemView);
+        }
+    }
+
+    public static class ViewHolder2 extends RecyclerView.ViewHolder {
+
+        public ViewHolder2(View itemView) {
+            super(itemView);
+        }
+    }
+
+    public static class ViewHolder3 extends RecyclerView.ViewHolder {
+
+        public ViewHolder3(View itemView) {
+            super(itemView);
+        }
+    }
+
+    public static class ViewHolder4 extends RecyclerView.ViewHolder {
+
+        public ViewHolder4(View itemView) {
+            super(itemView);
+        }
+    }
+
+    public static class ViewHolder5 extends RecyclerView.ViewHolder {
+
+        public ViewHolder5(View itemView) {
+            super(itemView);
+        }
+    }
+
+    public static class ViewHolder6 extends RecyclerView.ViewHolder {
+
+        public ViewHolder6(View itemView) {
+            super(itemView);
+        }
+    }
+
+
+    public static class ViewHolder7 extends RecyclerView.ViewHolder {
+
+        public ViewHolder7(View itemView) {
+            super(itemView);
+        }
+    }
+
+    public static class ViewHolder8 extends RecyclerView.ViewHolder {
+
+        public ViewHolder8(View itemView) {
+            super(itemView);
+        }
+    }
+
+    public static class ViewHolder9 extends RecyclerView.ViewHolder {
+
+        public ViewHolder9(View itemView) {
+            super(itemView);
+        }
+    }
+
+    public static class ViewHolder10 extends RecyclerView.ViewHolder {
+
+        public ViewHolder10(View itemView) {
+            super(itemView);
+        }
+    }
+
+    public static class ViewHolder11 extends RecyclerView.ViewHolder {
+
+        public ViewHolder11(View itemView) {
+            super(itemView);
+        }
+    }
+
+    public static class ViewHolder12 extends RecyclerView.ViewHolder {
+
+        public ViewHolder12(View itemView) {
+            super(itemView);
+        }
+    }
+
+    public static class ViewHolder13 extends RecyclerView.ViewHolder {
+
+        public ViewHolder13(View itemView) {
+            super(itemView);
+        }
+    }
+
+    public static class ViewHolder14 extends RecyclerView.ViewHolder {
+
+        public ViewHolder14(View itemView) {
+            super(itemView);
+        }
+    }
+
+    public static class ViewHolder15 extends RecyclerView.ViewHolder {
+
+        public ViewHolder15(View itemView) {
+            super(itemView);
+        }
+    }
+
+    public static class ViewHolder16 extends RecyclerView.ViewHolder {
+
+        public ViewHolder16(View itemView) {
+            super(itemView);
+        }
+    }
+
+    public static class ViewHolder17 extends RecyclerView.ViewHolder {
+
+        public ViewHolder17(View itemView) {
+            super(itemView);
+        }
+    }
+
+    public static class ViewHolder18 extends RecyclerView.ViewHolder {
+
+        public ViewHolder18(View itemView) {
+            super(itemView);
+        }
+    }
+
+    public static class ViewHolder19 extends RecyclerView.ViewHolder {
+
+        public ViewHolder19(View itemView) {
+            super(itemView);
+        }
+    }
+
+    public static class ViewHolder20 extends RecyclerView.ViewHolder {
+
+        public ViewHolder20(View itemView) {
+            super(itemView);
+        }
+    }
+}

--- a/examples/src/main/java/com/alibaba/android/vlayout/example/RootActivity.java
+++ b/examples/src/main/java/com/alibaba/android/vlayout/example/RootActivity.java
@@ -18,6 +18,7 @@ public class RootActivity extends ListActivity {
             MainActivity.class.getSimpleName(),
             TestActivity.class.getSimpleName(),
             OnePlusNLayoutActivity.class.getSimpleName(),
+            DynamicAdapterActivity.class.getSimpleName(),
             DebugActivity.class.getSimpleName()
     };
 
@@ -26,6 +27,7 @@ public class RootActivity extends ListActivity {
             MainActivity.class,
             TestActivity.class,
             OnePlusNLayoutActivity.class,
+            DynamicAdapterActivity.class,
             DebugActivity.class
     };
 

--- a/examples/src/main/res/layout/dynamic_adapter_activity.xml
+++ b/examples/src/main/res/layout/dynamic_adapter_activity.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/main_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#aaaaaa"
+        android:clipToPadding="true"
+        android:paddingLeft="0dp"
+        android:paddingRight="0dp"
+        android:requiresFadingEdge="none"
+        android:scrollbars="vertical" />
+
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|center">
+
+        <Button
+            android:id="@+id/display_history_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:text="history" />
+
+        <Button
+            android:id="@+id/add_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:text="add adapter" />
+
+        <Button
+            android:id="@+id/remove_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:text="remove adapter" />
+
+    </LinearLayout>
+
+</FrameLayout>

--- a/examples/src/main/res/layout/item.xml
+++ b/examples/src/main/res/layout/item.xml
@@ -36,6 +36,6 @@
         android:background="@drawable/item_background"
         android:gravity="center"
         android:textColor="#999999"
-        android:textSize="22sp"
+        android:textSize="16sp"
         android:textStyle="bold"/>
 </FrameLayout>

--- a/vlayout/src/main/java/com/alibaba/android/vlayout/VirtualLayoutManager.java
+++ b/vlayout/src/main/java/com/alibaba/android/vlayout/VirtualLayoutManager.java
@@ -222,6 +222,7 @@ public class VirtualLayoutManager extends ExposeLinearLayoutManagerEx implements
     private HashMap<Integer, LayoutHelper> oldHelpersSet = new HashMap<>();
 
     private BaseLayoutHelper.LayoutViewBindListener mLayoutViewBindListener;
+    private boolean mShouldCleanViewCaches;
 
     /**
      * Update layoutHelpers, data changes will cause layoutHelpers change
@@ -259,6 +260,8 @@ public class VirtualLayoutManager extends ExposeLinearLayoutManagerEx implements
 
                 start += helper.getItemCount();
             }
+        } else {
+            mShouldCleanViewCaches = true;
         }
 
         this.mHelperFinder.setLayouts(helpers);
@@ -1434,6 +1437,13 @@ public class VirtualLayoutManager extends ExposeLinearLayoutManagerEx implements
 
 
         super.detachAndScrapAttachedViews(recycler);
+        if (mShouldCleanViewCaches) {
+            mShouldCleanViewCaches = false;
+            removeAndRecycleAllViews(recycler);
+//            removeAndRecycleScrapInt(recycler);
+            recycler.clear();
+            mRecyclerView.getRecycledViewPool().clear();
+        }
     }
 
     @Override


### PR DESCRIPTION
动态添加或移除`Adapter`时，`CantorViewType`随着`Adapter`顺序变化，计算出来的结果也跟随改变, 这样可能复用到`RecyclerView`缓存的`ViewHolder`，导致类型转换异常

fix: #340 #336 #331 #216 