### PR TITLE
镜像环境，GridLayoutHelper不满SpanCount的行数条目位置未镜像问题

### DIFF
--- a/vlayout/src/main/java/com/alibaba/android/vlayout/layout/GridLayoutHelper.java
+++ b/vlayout/src/main/java/com/alibaba/android/vlayout/layout/GridLayoutHelper.java
@@ -24,19 +24,19 @@
 
 package com.alibaba.android.vlayout.layout;
 
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.util.LayoutDirection;
+import android.util.Log;
+import android.util.SparseIntArray;
+import android.view.View;
+import android.widget.TextView;
+
 import com.alibaba.android.vlayout.LayoutManagerHelper;
 import com.alibaba.android.vlayout.OrientationHelperEx;
 import com.alibaba.android.vlayout.VirtualLayoutManager;
 import com.alibaba.android.vlayout.VirtualLayoutManager.LayoutParams;
 import com.alibaba.android.vlayout.VirtualLayoutManager.LayoutStateWrapper;
-
-import android.support.annotation.NonNull;
-import android.support.v7.widget.OrientationHelper;
-import android.support.v7.widget.RecyclerView;
-import android.util.Log;
-import android.util.SparseIntArray;
-import android.view.View;
-import android.widget.TextView;
 
 import java.util.Arrays;
 
@@ -511,7 +511,13 @@ public class GridLayoutHelper extends BaseLayoutHelper {
 
         for (int i = 0; i < count; i++) {
             View view = mSet[i];
-            final int index = mSpanIndices[i];
+            int index = mSpanIndices[i];
+            //镜像环境，条目数据已镜像，但一行不满mSpanCount的条目位置没有镜像，需要移动mSpanCount - count位。
+            if (layoutState.getLayoutDirection() == LayoutDirection.RTL) {
+                if (count != mSpanCount) {
+                    index = index + mSpanCount - count;
+                }
+            }
 
             LayoutParams params = (LayoutParams) view.getLayoutParams();
             if (layoutInVertical) {


### PR DESCRIPTION
我们使用GridLayoutHelper在进行网格布局时，在镜像环境下，发现条目数据已经镜像了，满SpanCount的一行条目，位置也是镜像的，但一般最后一行不满SpanCount时，条目位置依旧是从左向右排列的，未达到镜像效果。此时，需要在child位置布局计算前，将child的index向右移动SpanCount-count（该行实际条目数）位，已达到位置镜像的效果。